### PR TITLE
Freeze folium and streamline-folium versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 streamlit
 streamlit-ace
 streamlit-searchbox
-streamlit-folium
-folium
+streamlit-folium==0.15.0
+folium==0.14.0
 ortools
 scikit-learn
 recurring-ical-events


### PR DESCRIPTION
There are documented compatibility issues with the very new release of folium and streamline that are still being resolved (https://github.com/randyzwitch/streamlit-folium/issues/148) 

For now, freezing requirements for those dependencies. 